### PR TITLE
D64: extraction of Floppy-IDs from Track18-Area

### DIFF
--- a/firmware/main.c
+++ b/firmware/main.c
@@ -1243,6 +1243,16 @@ int8_t open_g64_image(struct fat_file_struct* fd)
 
 int8_t open_d64_image(struct fat_file_struct* fd)
 {
+    // extract DiskID from Track18_BAM ($A2+$A3) .. better than nothing.
+    int32_t offset = (d64_track_offset[18] << 8) + 0xA2;
+    if(fat_seek_file(fd,&offset,FAT_SEEK_SET))
+    {
+        if (2 == fat_read_file(fd, d64_sector_puffer, 2))
+        {
+            id1 = d64_sector_puffer[0];
+            id2 = d64_sector_puffer[1];
+        }
+    }
     return 0;
 }
 

--- a/firmware/main.c
+++ b/firmware/main.c
@@ -1244,7 +1244,7 @@ int8_t open_g64_image(struct fat_file_struct* fd)
 int8_t open_d64_image(struct fat_file_struct* fd)
 {
     // extract DiskID from Track18_BAM ($A2+$A3) .. better than nothing.
-    int32_t offset = (d64_track_offset[18] << 8) + 0xA2;
+    int32_t offset = (((int32_t) d64_track_offset[track_nr]) << 8) + 0xA2;
     if(fat_seek_file(fd,&offset,FAT_SEEK_SET))
     {
         if (2 == fat_read_file(fd, d64_sector_puffer, 2))


### PR DESCRIPTION
reads 2 bytes from Track18 - Offset $A2+$A3 and stores it in
global variables for GCR track creation.
fixes issue #33